### PR TITLE
default_is_command_patch2

### DIFF
--- a/docs/config_options.md
+++ b/docs/config_options.md
@@ -87,7 +87,7 @@ This is a C header file that is one of the first things included, and will persi
   * mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap
 * `#define LOCKING_RESYNC_ENABLE`
   * tries to keep switch state consistent with keyboard LED state
-* `#define IS_COMMAND() ( keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) )`
+* `#define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))`
   * key combination that allows the use of magic commands (useful for debugging)
 * `#define USB_MAX_POWER_CONSUMPTION`
   * sets the maximum power (in mA) over USB for the device (default: 500)

--- a/keyboards/candybar/config.h
+++ b/keyboards/candybar/config.h
@@ -63,11 +63,6 @@
  */
 //#define FORCE_NKRO
 
-/* key combination for magic key command */
-#define IS_COMMAND() ( \
-  keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
-)
-
 /*
  * Feature disable options
  *  These options are also useful to firmware size reduction.

--- a/keyboards/plain60/config.h
+++ b/keyboards/plain60/config.h
@@ -45,11 +45,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCING_DELAY 5
 
-/* key combination for command */
-#define IS_COMMAND() ( \
-    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
-)
-
 #define QMK_ESC_OUTPUT D2 // usually COL
 #define QMK_ESC_INPUT B4 // usually ROW
 

--- a/tmk_core/protocol/usb_hid/test/config.h
+++ b/tmk_core/protocol/usb_hid/test/config.h
@@ -34,7 +34,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COLS 8
 
 
-/* key combination for command */
-#define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KB_LSHIFT) | MOD_BIT(KB_RSHIFT))) 
-
 #endif


### PR DESCRIPTION
You know the drill...

Merge master + remove redundant definitions from two new keyboards (candybar, plain60).
Also remove the definition in `tmk_core/protocol/usb_hid/test/config.h` that used <code>K<b>B</b>_LSHIFT</code> and <code>K<b>B</b>_RSHIFT</code> (idk what that's about, those constants aren't defined anywhere, so very likely a typo on TMK's part; either way, shouldn't be needed now).