### PR TITLE
Extern Ploopy dpi_array

### DIFF
--- a/keyboards/ploopyco/mouse/mouse.h
+++ b/keyboards/ploopyco/mouse/mouse.h
@@ -47,6 +47,7 @@ typedef union {
 } keyboard_config_t;
 
 extern keyboard_config_t keyboard_config;
+extern uint16_t          dpi_array[];
 
 enum ploopy_keycodes {
 #ifdef VIA_ENABLE

--- a/keyboards/ploopyco/trackball/trackball.h
+++ b/keyboards/ploopyco/trackball/trackball.h
@@ -52,6 +52,7 @@ typedef union {
 } keyboard_config_t;
 
 extern keyboard_config_t keyboard_config;
+extern uint16_t          dpi_array[];
 
 enum ploopy_keycodes {
 #ifdef VIA_ENABLE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Allows actual DPI values to be read in the _user functions, allowing keymap functions to go back to configured DPI values after a momentary switch.
This is particularly useful when setting up a button to engage high precision (100 DPI), then going back to previous DPI on release.
Similarly, users of the drag_scroll keymap who prefer a fixed DPI for drag scrolling may benefit in the same way.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
