### PR TITLE
Fix stuck audio on AVR is clicky is turned on

### DIFF
--- a/platforms/chibios/QMK_PROTON_C/configs/config.h
+++ b/platforms/chibios/QMK_PROTON_C/configs/config.h
@@ -18,3 +18,10 @@
 #ifndef EARLY_INIT_PERFORM_BOOTLOADER_JUMP
 #    define EARLY_INIT_PERFORM_BOOTLOADER_JUMP TRUE
 #endif
+
+
+#if defined(AUDIO_ENABLE) && defined(AUDIO_DRIVER_DAC) && !defined(AUDIO_PIN)
+#    define AUDIO_PIN A5
+#    define AUDIO_PIN_ALT A4
+#    define AUDIO_PIN_ALT_AS_NEGATIVE
+#endif

--- a/quantum/audio/audio.c
+++ b/quantum/audio/audio.c
@@ -424,7 +424,23 @@ bool audio_update_state(void) {
 
                 // '- delta': Skip forward in the next note's length if we've over shot
                 //            the last, so the overall length of the song is the same
-                uint16_t duration = audio_duration_to_ms((*notes_pointer)[current_note][1]) - delta;
+                uint16_t duration = audio_duration_to_ms((*notes_pointer)[current_note][1]);
+
+                // Skip forward past any completely missed notes
+                while (delta > duration && current_note < notes_count - 1) {
+                    delta -= duration;
+                    current_note++;
+                    duration = audio_duration_to_ms((*notes_pointer)[current_note][1]);
+                }
+
+                if (delta < duration) {
+                    duration -= delta;
+                } else {
+                    // Only way to get here is if it is the last note and
+                    // we have completely missed it. Play it for 1ms...
+                    duration = 1;
+                }
+
                 audio_play_note((*notes_pointer)[current_note][0], duration);
                 melody_current_note_duration = duration;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Audio was getting stuck on AVR when clicky was turned on, when using the overhauled audio code.

The problem is that if `audio_update_state()` can be called late enough that a note has been missed entirely. That makes `delta > duration`, so the adjusted duration is negative (underflow). The solution is to add a loop to skip past any notes that have been missed entirely.

The problem was not noticed on ARM because the MCUs are fast enough that there were no completely missed notes.

The updated code has been tested on Teensy 2++ and on QMK Proton C.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
