### PR TITLE
Fix pimoroni trackball

### DIFF
--- a/quantum/pointing_device_drivers.c
+++ b/quantum/pointing_device_drivers.c
@@ -76,7 +76,7 @@ report_mouse_t pimorono_trackball_get_report(report_mouse_t mouse_report) {
             error_count = 0;
 
             if (!(pimoroni_data.click & 128)) {
-                mouse_report.buttons |= MOUSE_BTN1;
+                mouse_report.buttons &= ~MOUSE_BTN1;
                 if (!debounce) {
                     x_offset += pimoroni_trackball_get_offsets(pimoroni_data.right, pimoroni_data.left, PIMORONI_TRACKBALL_MOUSE_SCALE);
                     y_offset += pimoroni_trackball_get_offsets(pimoroni_data.down, pimoroni_data.up, PIMORONI_TRACKBALL_MOUSE_SCALE);
@@ -86,15 +86,14 @@ report_mouse_t pimorono_trackball_get_report(report_mouse_t mouse_report) {
                     debounce--;
                 }
             } else {
-                mouse_report.buttons &= ~MOUSE_BTN1;
+                mouse_report.buttons |= MOUSE_BTN1;
                 debounce = PIMORONI_TRACKBALL_DEBOUNCE_CYCLES;
             }
+        } else {
+            error_count++;
         }
-    } else {
-        error_count++;
+        throttle = timer_read_fast();
     }
-
-    throttle = timer_read_fast();
     return mouse_report;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The mouse button logic was reversed and throttle timer was always being reset so trackball was never read.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bugfix